### PR TITLE
Fix docs link for @tomic/react in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yarn start # run the server!
 
 Library with `Store`, `Commit`, `JSON-AD` parsing, and more.
 
-[**docs**](https://joepio.github.io/atomic-data-browser/docs/modules/_tomic_lib.html)
+[**docs**](https://atomicdata-dev.github.io/atomic-data-browser/docs/modules/_tomic_lib.html)
 
 [→ Read more](lib/README.md)
 
@@ -59,7 +59,7 @@ React library with many useful hooks for rendering and editing Atomic Data.
 
 [**demo + template on codesandbox**](https://codesandbox.io/s/atomic-data-react-template-4y9qu?file=/src/MyResource.tsx:0-1223)
 
-[**docs**](https://joepio.github.io/atomic-data-browser/docs/modules/_tomic_react.html)
+[**docs**](https://atomicdata-dev.github.io/atomic-data-browser/docs/modules/_tomic_react.html)
 
 [→ Read more](react/README.md)
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,5 +1,5 @@
 # @tomic/lib: The Atomic Data library for typescript / javascript
 
-[**docs**](https://joepio.github.io/atomic-data-browser/docs/modules/_tomic_lib.html)
+[**docs**](https://atomicdata-dev.github.io/atomic-data-browser/docs/modules/_tomic_lib.html)
 
 Core typescript library for handling JSON-AD parsing, storing [Atomic Data](https://docs.atomicdata.dev/), signing Commits, and more.

--- a/react/README.md
+++ b/react/README.md
@@ -5,7 +5,6 @@ Re-exports `@tomic/lib`.
 
 [**demo + template on codesandbox**!](https://codesandbox.io/s/atomic-data-react-template-4y9qu?file=/src/MyResource.tsx:0-1223)
 
-
 [**docs**](https://atomicdata-dev.github.io/atomic-data-browser/docs/modules/_tomic_react.html)
 
 ## Setup

--- a/react/README.md
+++ b/react/README.md
@@ -5,7 +5,8 @@ Re-exports `@tomic/lib`.
 
 [**demo + template on codesandbox**!](https://codesandbox.io/s/atomic-data-react-template-4y9qu?file=/src/MyResource.tsx:0-1223)
 
-[**docs**](https://joepio.github.io/atomic-data-browser/docs/modules/_tomic_react.html)
+
+[**docs**](https://atomicdata-dev.github.io/atomic-data-browser/docs/modules/_tomic_react.html)
 
 ## Setup
 


### PR DESCRIPTION
Fixes the links to API docs for @tomic/react and @tomic/lib in READMEs.

Closes #160?