### PR TITLE
Fix Race condition of `store.getResourceAsync` #309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog covers all three packages, as they are (for now) updated as a who
 - Add new file preview types to the folder grid view.
 - Add `store.preloadClassesAndProperties` and remove `urls.properties.getAll` and `urls.classes.getAll`. This enables using `atomic-data-browser` without relying on `atomicdata.dev` being available.
 - Fix Dialogue form #308
+- Fix Race condition of `store.getResourceAsync` #309
 
 ## v0.35.0
 


### PR DESCRIPTION
PR Checklist:

- [x] Link to related issues: #309 
- [x] Add changelog entry linking to issue
- [ ] Add tests (if needed)
- [ ] If dependent on server-side changes: link to PR on `atomic-data-rust`
- [ ] If new feature: added in description / readme
